### PR TITLE
feat: Add transaction success and rollback demo with move-to-front op…

### DIFF
--- a/lab5/routes/queueRoutes.js
+++ b/lab5/routes/queueRoutes.js
@@ -12,5 +12,6 @@ router.post("/:id/next", queueController.nextInQueue);
 router.post("/:id/remove/:userId", queueController.removeUserFromQueue);
 router.post("/:id/close", queueController.closeQueue);
 router.post("/:id/delete", queueController.deleteQueue);
+router.post('/:id/move-to-front', queueController.moveUserToFront);
 
 export default router;

--- a/lab5/views/queue.ejs
+++ b/lab5/views/queue.ejs
@@ -23,17 +23,26 @@
           <li><%= user.name %></li>
         <% }) %>
       </ul>
-      <form action="/<%= queue.id %>/join" method="post">
-        <input type="text" name="userId" placeholder="ID користувача" required />
-        <button type="submit">Приєднатися до черги</button>
-      </form>
+      <% if (!queue.is_closed) { %>
+        <form action="/<%= queue.id %>/join" method="post">
+          <input type="text" name="userId" placeholder="ID користувача" required />
+          <button type="submit">Приєднатися до черги</button>
+        </form>
+      <% } %>
       <form action="/<%= queue.id %>/next" method="post">
         <input type="text" name="ownerId" placeholder="ID власника" required />
         <button type="submit">Наступний</button>
       </form>
-      <form action="/<%= queue.id %>/close" method="post">
+      <% if (!queue.is_closed) { %>
+        <form action="/<%= queue.id %>/close" method="post">
+          <input type="text" name="ownerId" placeholder="ID власника" required />
+          <button type="submit">Закрити чергу</button>
+        </form>
+      <% } %>
+      <form action="/<%= queue.id %>/move-to-front" method="post">
         <input type="text" name="ownerId" placeholder="ID власника" required />
-        <button type="submit">Закрити чергу</button>
+        <input type="text" name="userId" placeholder="ID користувача для переміщення" required />
+        <button type="submit">Перемістити на початок</button>
       </form>
       <form action="/<%= queue.id %>/delete" method="post">
         <input type="text" name="ownerId" placeholder="ID власника" required />


### PR DESCRIPTION
- Modified queueService.js to support transaction demo:
  - Kept queue closure check to trigger transaction rollback when queue is closed
  - Added logging for successful moves and failed transactions
- Updated queue.ejs:
  - Made move-to-front form always visible, regardless of queue status, to enable demo
  - Allows demonstrating successful transaction (open queue) and rollback (closed queue)